### PR TITLE
 支持 --service / -i 仅生成指定 swagger 服务

### DIFF
--- a/config.d.ts
+++ b/config.d.ts
@@ -24,6 +24,9 @@ export interface IIncludeInterface {
 }
 
 export interface IConfigSwaggerServer {
+	/** 服务名称，作为 `anl type --service <name>` 的匹配标识，建议在多服务场景下显式指定。
+	 * 未指定时，会回退到 apiListFileName 去扩展名后的值作为标识。 */
+	name?: string;
 	/** swagger json 的 url */
 	url: string;
 	/** 公共前缀 */

--- a/docs/en/anl-type.md
+++ b/docs/en/anl-type.md
@@ -156,6 +156,90 @@ $ anl type -l warn -f -s miss
 
 For level descriptions, see [Log Level](#log-level-loglevel).
 
+#### Regenerate Selected Services Only (-S / --service)
+
+When `swaggerConfig` defines multiple swagger services, `anl type` defaults to a **full regeneration** (clean directories → regenerate everything). To refresh only one or a few services while keeping the others' generated files untouched, use the `-S` / `--service` flag.
+
+##### Examples
+
+```bash
+# Regenerate only the `op` service
+$ anl type -S op
+
+# Regenerate multiple services (comma-separated)
+$ anl type --service op,notice
+
+# Combine with other flags
+$ anl type -S op -f -s miss
+```
+
+##### Matching Rules
+
+- Match against the service `name` field first (recommended for stable identifiers)
+- Fall back to `apiListFileName` without its extension (e.g. `op.ts` → `op`)
+- Case-insensitive
+- If any token does not match, the command fails with a list of available services and exits with code `1`
+
+##### Option
+
+- **Option**: `-S, --service <names>`
+- **Values**: One or more service identifiers, comma-separated
+- **Priority**: CLI flag > interactive picker > full regeneration
+
+##### Selective Mode Guarantees
+
+- Only the selected services' API file, `connectors/<segment>` and `models/<segment>` directories are cleaned
+- The **shared enum directory is never wiped** (so other services' enums are preserved)
+- The top-level `models/index.ts` barrel is updated with a "read → merge → dedupe → write" strategy, **preserving other services' `export *` lines**
+- Under selective mode, `--format` only formats the selected services' generated files
+
+#### Interactive Picker (auto-triggered for multi-service configs)
+
+`anl type` automatically opens an inquirer multi-select prompt when **all** of the following are true:
+
+1. `swaggerConfig` defines **2 or more** services
+2. `-S` / `--service` is **not** provided
+3. The current process is attached to a **TTY** (not CI / not piped)
+
+##### Example
+
+```bash
+$ anl type
+Multiple swagger services detected. Please pick the ones to regenerate this run:
+? Select services to regenerate (empty selection = all): (Press <space> to select, <a> to toggle all)
+❯◯ op  (op.ts  ←  https://app.op.dev.dotfortune.com/order/v3/api-docs)
+ ◯ notice  (notice.ts  ←  http://dot-common.dev.dotfortune.net/v3/api-docs/op-notice)
+ ...
+```
+
+- Empty selection → treated as "all" → falls back to full regeneration
+- Selecting 1..N items → selective regeneration
+- In non-TTY environments (CI / pipes) the interactive prompt is skipped and full regeneration runs
+
+#### Service Naming (`swaggerConfig[i].name`)
+
+Declaring a `name` for each service gives you:
+
+- A **stable, human-readable** identifier for both `-S, --service` and the interactive picker
+- Decoupling from `apiListFileName` — renaming the output file no longer breaks your CLI usage
+
+```typescript
+swaggerConfig: [
+	{
+		name: 'op', // recommended
+		url: 'https://example.com/order/v3/api-docs',
+		apiListFileName: 'op.ts',
+	},
+	{
+		name: 'notice',
+		url: 'https://example.com/notice/v3/api-docs',
+		apiListFileName: 'notice.ts',
+	},
+],
+```
+
+> In multi-service configs, both `name` and `apiListFileName` must be globally unique. When `name` is omitted, the segment derived from `apiListFileName` (extension stripped) is used for matching.
+
 ### Configuration File Details
 
 #### TypeScript Configuration File (Recommended)

--- a/docs/zh-cn/anl-type.md
+++ b/docs/zh-cn/anl-type.md
@@ -158,6 +158,90 @@ $ anl type -l warn -f -s miss
 
 详细级别说明见[日志输出级别](#日志输出级别-loglevel)。
 
+#### 仅生成指定服务（-S / --service）
+
+当 `swaggerConfig` 配置了多个 swagger 服务时，默认 `anl type` 会**全量重生成所有服务**（清空目录 → 重新生成）。如果只想刷新其中的某一个或几个服务（其他服务的产物保持不变），可以使用 `-S` / `--service` 参数。
+
+##### 使用示例
+
+```bash
+# 仅重新生成 op 服务
+$ anl type -S op
+
+# 同时重新生成多个服务，逗号分隔
+$ anl type --service op,notice
+
+# 与其他参数组合
+$ anl type -S op -f -s miss
+```
+
+##### 匹配规则
+
+- 优先按服务的 `name` 字段匹配（推荐显式声明，命名稳定）
+- 若未声明 `name`，则回退到 `apiListFileName` 去掉扩展名后的值（例如 `op.ts` → `op`）
+- 大小写不敏感
+- 任意一个 token 未匹配 → 报错并列出所有可用服务名，进程退出码为 1
+
+##### 参数说明
+
+- **参数**：`-S, --service <names>`
+- **可选值**：单个或多个服务标识，逗号分隔
+- **优先级**：命令行参数 > 交互式选择 > 全量
+
+##### 选择型生成的行为约定
+
+- 仅清理被选中服务的 API 文件、`connectors/<segment>` 与 `models/<segment>` 子目录
+- **共享的 enum 目录不会被清空**（避免误删其他服务定义的枚举）
+- 顶层 `models/index.ts` 采用"读取-合并-去重-写回"策略，**保留其他服务的 `export *`**
+- `--format` 在选择型模式下仅格式化被选中服务的产物
+
+#### 交互式多选（多服务自动触发）
+
+当满足以下条件时，`anl type` 会自动弹出 inquirer 多选框，让你勾选本次需要重新生成的服务：
+
+1. `swaggerConfig` 配置了 **2 个及以上** 服务
+2. 未传 `-S` / `--service`
+3. 当前是 **TTY 终端**（非 CI / 非管道）
+
+##### 使用示例
+
+```bash
+$ anl type
+检测到多个 swagger 服务，请选择本次要重新生成的服务：
+? 请选择需要重新生成的 swagger 服务（空选 = 全部）： (Press <space> to select, <a> to toggle all)
+❯◯ op  (op.ts  ←  https://app.op.dev.dotfortune.com/order/v3/api-docs)
+ ◯ notice  (notice.ts  ←  http://dot-common.dev.dotfortune.net/v3/api-docs/op-notice)
+ ...
+```
+
+- 不勾选任何项 → 视为"全部" → 走全量行为，与 `anl type` 单服务时一致
+- 勾选 1 ~ N 项 → 走选择型行为
+- 非 TTY 环境（CI / 管道）会自动跳过交互，回退到全量行为
+
+#### 服务命名（`swaggerConfig[i].name`）
+
+为每个服务声明 `name` 字段，可获得：
+
+- 在 `-S, --service` 与交互式多选中拥有**稳定、易读**的标识
+- 即使将来调整 `apiListFileName`，命令行用法不受影响
+
+```typescript
+swaggerConfig: [
+	{
+		name: 'op', // 推荐显式声明
+		url: 'https://example.com/order/v3/api-docs',
+		apiListFileName: 'op.ts',
+	},
+	{
+		name: 'notice',
+		url: 'https://example.com/notice/v3/api-docs',
+		apiListFileName: 'notice.ts',
+	},
+],
+```
+
+> 多服务下，`name` 与 `apiListFileName` 都需要全局唯一。未声明 `name` 时仍可使用 `apiListFileName` 去扩展名后的值匹配。
+
 ### 配置文件详解
 
 #### TypeScript 配置文件（推荐）

--- a/package.json
+++ b/package.json
@@ -27,7 +27,11 @@
 		"pub": "bash publish.sh",
 		"ts": "tsc ./src/int.ts --noEmit --watch",
 		"blink": "pnpm run build && pnpm link",
-		"docs": "docsify serve ./docs"
+		"docs": "docsify serve ./docs",
+		"test:type": "node bin/an-cli.js type",
+		"test:type:one": "node bin/an-cli.js type -S op",
+		"test:type:multi": "node bin/an-cli.js type -S op,notice",
+		"test:type:miss": "node bin/an-cli.js type -S notExist"
 	},
 	"bin": {
 		"anl": "bin/an-cli.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,11 @@ program
 	.option('-s, --show <what>', 'show interface list after generation: miss | gen')
 	.option('-f, --format [config]', 'enable prettier formatting after generation; optionally specify a prettier config file path (e.g. --format .prettierrc.mjs)')
 	.option('-l, --log-level <level>', 'set log output level: silent | error | warn | info | verbose')
-	.action((options: { show?: string; format?: string | boolean; logLevel?: string }) => {
+	.option(
+		'-S, --service <names>',
+		'only regenerate the specified swagger service(s); comma-separated. Match by `name` (preferred) or `apiListFileName` without extension. Other services are kept untouched.',
+	)
+	.action((options: { show?: string; format?: string | boolean; logLevel?: string; service?: string }) => {
 		const raw = (options.show ?? '').toLowerCase().trim();
 		const show =
 			raw === 'miss' || raw === 'missing' || raw === 'm' || raw === 'exclude' || raw === 'x'
@@ -23,8 +27,14 @@ program
 				: raw === 'gen' || raw === 'generated' || raw === 'g' || raw === 'include' || raw === 'i'
 					? 'gen'
 					: undefined;
+		const services = options.service
+			? options.service
+					.split(',')
+					.map((s) => s.trim())
+					.filter(Boolean)
+			: undefined;
 		const Instance = new Main();
-		Instance.initialize(show, options.format, options.logLevel).catch((error) => {
+		Instance.initialize(show, options.format, options.logLevel, services).catch((error) => {
 			console.error(error);
 		});
 	});

--- a/src/swagger-codegen/index.ts
+++ b/src/swagger-codegen/index.ts
@@ -3,6 +3,7 @@ import type { OpenAPIV3 } from 'openapi-types';
 
 import chalk from 'chalk';
 import fs from 'fs';
+import inquirer from 'inquirer';
 import { createJiti } from 'jiti';
 import path from 'path';
 import { exec } from 'shelljs';
@@ -48,8 +49,8 @@ const configContent: ConfigType = {
 	},
 };
 
-type NormalizedSwaggerServer = Required<Omit<IConfigSwaggerServer, 'responseModelTransform' | 'includeTags' | 'excludeTags' | 'timeout'>> &
-	Pick<IConfigSwaggerServer, 'responseModelTransform' | 'includeTags' | 'excludeTags' | 'timeout'>;
+type NormalizedSwaggerServer = Required<Omit<IConfigSwaggerServer, 'name' | 'responseModelTransform' | 'includeTags' | 'excludeTags' | 'timeout'>> &
+	Pick<IConfigSwaggerServer, 'name' | 'responseModelTransform' | 'includeTags' | 'excludeTags' | 'timeout'>;
 
 export class Main {
 	private schemas: ComponentsSchemas = {};
@@ -379,6 +380,9 @@ export class Main {
 			};
 
 			// 可选字段需要单独处理
+			if (server.name?.trim()) {
+				result.name = server.name.trim();
+			}
 			if (includeTags !== undefined) {
 				result.includeTags = includeTags;
 			}
@@ -402,6 +406,16 @@ export class Main {
 					throw new Error(`swaggerConfig 中 apiListFileName 重复：${server.apiListFileName}，请为每个服务设置唯一文件名。`);
 				}
 				nameSet.add(server.apiListFileName);
+			});
+
+			// 同时校验 name 全局唯一（仅检查显式提供的 name）
+			const explicitNameSet = new Set<string>();
+			normalized.forEach((server) => {
+				if (!server.name) return;
+				if (explicitNameSet.has(server.name)) {
+					throw new Error(`swaggerConfig 中 name 重复：${server.name}，请为每个服务设置唯一名称。`);
+				}
+				explicitNameSet.add(server.name);
 			});
 		}
 
@@ -543,7 +557,76 @@ export default defineConfig({
 `;
 	}
 
-	async initialize(show?: 'miss' | 'gen', formatOption?: string | boolean, logLevel?: string): Promise<void> {
+	/**
+	 * 解析 --service 输入，定位选中的服务索引集合。
+	 * 匹配优先级：name（显式声明） > apiListFileName 去扩展名（即 segment 派生值）。
+	 * 不匹配的 token 会汇总后报错。
+	 */
+	private resolveSelectedServiceIndices(servers: NormalizedSwaggerServer[], requested: string[]): number[] {
+		const tokenToIndex = new Map<string, number>();
+		servers.forEach((server, idx) => {
+			if (server.name) {
+				tokenToIndex.set(server.name.toLowerCase(), idx);
+			}
+		});
+		// apiListFileName 去扩展名作为兜底匹配，且不会覆盖已有 name 索引
+		servers.forEach((server, idx) => {
+			const seg = computeSegment(server.apiListFileName).toLowerCase();
+			if (seg && !tokenToIndex.has(seg)) {
+				tokenToIndex.set(seg, idx);
+			}
+		});
+
+		const selected = new Set<number>();
+		const unknown: string[] = [];
+		for (const raw of requested) {
+			const key = raw.toLowerCase();
+			const idx = tokenToIndex.get(key);
+			if (idx === undefined) unknown.push(raw);
+			else selected.add(idx);
+		}
+
+		if (unknown.length) {
+			const available = servers
+				.map((s) => s.name || computeSegment(s.apiListFileName))
+				.filter(Boolean)
+				.join(', ');
+			throw new Error(`未找到匹配的 swagger 服务：${unknown.join(', ')}。可用服务：${available || '<无>'}`);
+		}
+
+		return Array.from(selected).sort((a, b) => a - b);
+	}
+
+	/**
+	 * 交互式选择需要重新生成的服务（多选）。
+	 * 仅在 TTY 环境调用，调用方需要确保 stdout/stdin 是 TTY。
+	 */
+	private async promptSelectServices(servers: NormalizedSwaggerServer[]): Promise<number[]> {
+		const choices = servers.map((server, idx) => {
+			const id = server.name || computeSegment(server.apiListFileName) || `#${idx}`;
+			return {
+				name: `${id}  (${server.apiListFileName}  ←  ${server.url})`,
+				value: idx,
+				short: id,
+			};
+		});
+
+		const { picked } = await inquirer.prompt<{ picked: number[] }>([
+			{
+				type: 'checkbox',
+				name: 'picked',
+				message: '请选择需要重新生成的 swagger 服务（空选 = 全部）：',
+				choices,
+				pageSize: Math.min(20, choices.length),
+			},
+		]);
+
+		// 空选视为全选，保持与传统全量行为一致
+		if (!picked || picked.length === 0) return servers.map((_, i) => i);
+		return picked.sort((a, b) => a - b);
+	}
+
+	async initialize(show?: 'miss' | 'gen', formatOption?: string | boolean, logLevel?: string, requestedServices?: string[]): Promise<void> {
 		const projectRoot = process.cwd();
 
 		try {
@@ -561,21 +644,8 @@ export default defineConfig({
 
 			if (!isConfigFile) return;
 
-			// 创建目标目录（如果不存在）
-			await fs.promises.mkdir(mergedConfig.saveApiListFolderPath, { recursive: true });
-
-			// 复制 ajax 配置文件
-			await this.copyAjaxConfigFiles(mergedConfig.saveApiListFolderPath);
-
-			// 清理文件夹
-			// 清理 API 文件夹，但保留配置文件
-			await clearDirExcept(mergedConfig.saveApiListFolderPath, ['config']);
-			await clearDir(mergedConfig.saveTypeFolderPath);
-			await clearDir(mergedConfig.saveEnumFolderPath);
-
-			const showSummary: { serverUrl: string; list: { path: string; method: string }[] }[] = [];
-
 			// 多服务时按 apiListFileName 派生 segment 进行目录隔离，并校验 segment 唯一性
+			// 注意：isolateBySegment 必须基于 "原始 servers 总数"，与 --service 过滤无关
 			const isolateBySegment = servers.length > 1;
 			const segments = isolateBySegment ? servers.map((s) => computeSegment(s.apiListFileName)) : servers.map(() => '');
 			if (isolateBySegment) {
@@ -593,25 +663,66 @@ export default defineConfig({
 				});
 			}
 
+			// 决定本次需要生成的服务索引
+			let selectedIndices: number[];
+			let isSelective: boolean;
+			if (requestedServices?.length) {
+				selectedIndices = this.resolveSelectedServiceIndices(servers, requestedServices);
+				isSelective = selectedIndices.length !== servers.length;
+			} else if (servers.length > 1 && process.stdin.isTTY && process.stdout.isTTY) {
+				// 多服务且交互式终端：弹出多选
+				log.print(chalk.cyan('\n检测到多个 swagger 服务，请选择本次要重新生成的服务：'));
+				selectedIndices = await this.promptSelectServices(servers);
+				isSelective = selectedIndices.length !== servers.length;
+			} else {
+				selectedIndices = servers.map((_, i) => i);
+				isSelective = false;
+			}
+
+			// 打印本次执行计划
+			this.printExecutionPlan(servers, selectedIndices, isSelective);
+
+			// 创建目标目录（如果不存在）
+			await fs.promises.mkdir(mergedConfig.saveApiListFolderPath, { recursive: true });
+
+			// 复制 ajax 配置文件
+			await this.copyAjaxConfigFiles(mergedConfig.saveApiListFolderPath);
+
+			if (isSelective) {
+				// 选择型：精准清理被选中的服务对应文件/目录，绝不动其他服务的产物
+				await this.cleanSelectedTargets(mergedConfig, servers, selectedIndices, segments, isolateBySegment);
+			} else {
+				// 全量：保持原有清理策略
+				await clearDirExcept(mergedConfig.saveApiListFolderPath, ['config']);
+				await clearDir(mergedConfig.saveTypeFolderPath);
+				await clearDir(mergedConfig.saveEnumFolderPath);
+			}
+
+			const showSummary: { serverUrl: string; list: { path: string; method: string }[] }[] = [];
+
 			// 逐个 swagger 服务生成
-			for (let i = 0; i < servers.length; i++) {
+			// 选择型：appendMode 恒为 true（基于已有 index 合并写入，不会污染其他服务）
+			// 全量：保持原行为，第一个服务负责重写 index，后续 append
+			for (let order = 0; order < selectedIndices.length; order++) {
+				const i = selectedIndices[order];
 				const serverConfig = this.buildServerConfig(mergedConfig, servers[i], segments[i]);
-				const appendMode = i > 0;
+				const appendMode = isSelective ? true : order > 0;
 				const list = await this.handle(serverConfig, appendMode, show);
 				if (show && list) showSummary.push({ serverUrl: servers[i].url, list });
 			}
 
-			// 多服务隔离时，生成顶层 models 聚合 barrel，便于下游统一从 saveTypeFolderPath/models 导入
+			// 多服务隔离时，写入顶层 models 聚合 barrel
 			if (isolateBySegment) {
-				const barrelPath = `${mergedConfig.saveTypeFolderPath}/models/index.ts`;
-				const barrelContent = segments.map((seg) => `export * from './${seg}';`).join('\n') + '\n';
-				await writeFileRecursive(barrelPath, barrelContent);
-				log.info(`${barrelPath} - Top-level models barrel written.`);
+				await this.writeTopLevelModelsBarrel(mergedConfig, segments, selectedIndices, isSelective);
 			}
 
 			// 对生成文件进行格式化（仅当用户传入 --format 参数时执行）
 			if (formatOption !== undefined && formatOption !== false) {
-				await this.formatGeneratedFiles(mergedConfig, formatOption);
+				if (isSelective) {
+					await this.formatSelectedFiles(mergedConfig, servers, selectedIndices, segments, isolateBySegment, formatOption);
+				} else {
+					await this.formatGeneratedFiles(mergedConfig, formatOption);
+				}
 			}
 
 			log.banner('All done — see you next time!');
@@ -619,7 +730,7 @@ export default defineConfig({
 			if (show && showSummary.length > 0) {
 				const label = show === 'miss' ? 'excludeInterface' : 'includeInterface';
 				for (const { serverUrl, list } of showSummary) {
-					if (servers.length > 1) log.print(chalk.cyan(`\n[${label}] ${serverUrl}`));
+					if (selectedIndices.length > 1) log.print(chalk.cyan(`\n[${label}] ${serverUrl}`));
 					else log.print(chalk.cyan(`\n[${label}]`));
 					log.print(JSON.stringify(list, null, 2));
 				}
@@ -628,6 +739,165 @@ export default defineConfig({
 		} catch (error: unknown) {
 			const message = error instanceof Error ? error.message : 'Unknown error';
 			log.error(`Initialization failed: ${message}`);
+			process.exitCode = 1;
+		}
+	}
+
+	/**
+	 * 打印本次将要执行的服务清单（选中/跳过）。
+	 */
+	private printExecutionPlan(servers: NormalizedSwaggerServer[], selectedIndices: number[], isSelective: boolean): void {
+		const selectedSet = new Set(selectedIndices);
+		log.print(chalk.cyan(isSelective ? '\n[anl type] 选择型生成，仅处理以下服务：' : '\n[anl type] 全量生成，将处理所有服务：'));
+		servers.forEach((server, idx) => {
+			const id = server.name || computeSegment(server.apiListFileName) || `#${idx}`;
+			if (selectedSet.has(idx)) {
+				log.print(`  ${chalk.green('●')} ${id}  (${server.apiListFileName})  ${chalk.gray(server.url)}`);
+			} else {
+				log.print(`  ${chalk.gray('○ skip ')}${id}  (${server.apiListFileName})  ${chalk.gray(server.url)}`);
+			}
+		});
+		log.print('');
+	}
+
+	/**
+	 * 选择型清理：仅删除被选中服务对应的 API 文件、connectors/<seg>、models/<seg>。
+	 * 共享的 enum 目录不清理（写入时按文件覆盖，index.ts 通过 appendMode 合并去重）。
+	 */
+	private async cleanSelectedTargets(
+		baseConfig: ConfigType,
+		servers: NormalizedSwaggerServer[],
+		selectedIndices: number[],
+		segments: string[],
+		isolateBySegment: boolean,
+	): Promise<void> {
+		for (const i of selectedIndices) {
+			const apiFilePath = `${baseConfig.saveApiListFolderPath}/${servers[i].apiListFileName}`;
+			await clearDir(apiFilePath);
+
+			if (isolateBySegment) {
+				const seg = segments[i];
+				if (seg) {
+					await clearDir(`${baseConfig.saveTypeFolderPath}/connectors/${seg}`);
+					await clearDir(`${baseConfig.saveTypeFolderPath}/models/${seg}`);
+				}
+			} else {
+				// 单服务模式 = 全量等价，按全量逻辑清理
+				await clearDir(`${baseConfig.saveTypeFolderPath}/connectors`);
+				await clearDir(`${baseConfig.saveTypeFolderPath}/models`);
+			}
+		}
+	}
+
+	/**
+	 * 顶层 models/index.ts 聚合 barrel 写入。
+	 * 全量：直接重写为所有 segment 的导出。
+	 * 选择型：读取现有 barrel + 合并所选 segment 的导出，去重写回，避免丢失其他服务的导出。
+	 */
+	private async writeTopLevelModelsBarrel(baseConfig: ConfigType, segments: string[], selectedIndices: number[], isSelective: boolean): Promise<void> {
+		const barrelPath = `${baseConfig.saveTypeFolderPath}/models/index.ts`;
+
+		const targetSegments = isSelective ? selectedIndices.map((i) => segments[i]).filter(Boolean) : segments.filter(Boolean);
+		const newExports = targetSegments.map((seg) => `export * from './${seg}';`);
+
+		let merged: string[];
+		if (isSelective) {
+			let existing: string[] = [];
+			try {
+				const current = await fs.promises.readFile(barrelPath, 'utf8');
+				existing = current.split('\n').filter((line) => line.trim() !== '');
+			} catch {
+				existing = [];
+			}
+			const set = new Set(existing);
+			merged = [...existing];
+			for (const line of newExports) {
+				if (!set.has(line)) {
+					merged.push(line);
+					set.add(line);
+				}
+			}
+		} else {
+			merged = newExports;
+		}
+
+		const content = merged.join('\n') + '\n';
+		await writeFileRecursive(barrelPath, content);
+		log.info(`${barrelPath} - Top-level models barrel ${isSelective ? 'merged' : 'written'}.`);
+	}
+
+	/**
+	 * 选择型格式化：仅格式化被选中的服务对应的产物，避免误格式化其他服务文件。
+	 */
+	private async formatSelectedFiles(
+		config: ConfigType,
+		servers: NormalizedSwaggerServer[],
+		selectedIndices: number[],
+		segments: string[],
+		isolateBySegment: boolean,
+		formatOption: string | boolean,
+	): Promise<void> {
+		const targets: string[] = [];
+		for (const i of selectedIndices) {
+			const apiFile = `${config.saveApiListFolderPath}/${servers[i].apiListFileName}`;
+			try {
+				await fs.promises.access(apiFile);
+				targets.push(`"${apiFile}"`);
+			} catch {
+				/* ignore */
+			}
+
+			const segDirs =
+				isolateBySegment && segments[i]
+					? [`${config.saveTypeFolderPath}/connectors/${segments[i]}`, `${config.saveTypeFolderPath}/models/${segments[i]}`]
+					: [`${config.saveTypeFolderPath}/connectors`, `${config.saveTypeFolderPath}/models`];
+			for (const dir of segDirs) {
+				try {
+					await fs.promises.access(dir);
+					targets.push(`"${dir}/**/*.{ts,d.ts}"`);
+				} catch {
+					/* ignore */
+				}
+			}
+		}
+
+		if (targets.length === 0) {
+			log.warning('No files to format for the selected services.');
+			return;
+		}
+
+		const prettierBin = await this.resolvePrettierExecutable();
+		let configFlag = '';
+		if (typeof formatOption === 'string' && formatOption.trim()) {
+			const configPath = path.resolve(process.cwd(), formatOption.trim());
+			try {
+				await fs.promises.access(configPath);
+				configFlag = ` --config "${configPath}"`;
+			} catch {
+				const detected = await this.detectPrettierConfig();
+				if (detected) configFlag = ` --config "${detected}"`;
+			}
+		} else {
+			const detected = await this.detectPrettierConfig();
+			if (detected) configFlag = ` --config "${detected}"`;
+		}
+
+		const formatCommand = `${prettierBin} --write ${targets.join(' ')}${configFlag}`;
+		try {
+			spinner.start('Formatting selected files...');
+			await new Promise<void>((resolve, reject) => {
+				exec(formatCommand, (error) => {
+					if (error) reject(new Error(String(error)));
+					else resolve();
+				});
+			});
+			spinner.success('File formatting successful');
+			log.print('\n');
+		} catch (error: unknown) {
+			spinner.error('Format failed');
+			log.print(error);
+			log.error('Format failed, please manually execute the following command:');
+			log.print('$', chalk.yellow(formatCommand));
 		}
 	}
 }


### PR DESCRIPTION
- 新增 swaggerConfig[i].name 字段作为稳定标识
- type 命令新增 -S, --service <names> 按 name / apiListFileName 过滤
- 多服务 + TTY + 未传 -S 时自动弹出 inquirer 多选（空选=全部）
- 选择型生成：精准清理 API 文件与 connectors/models 子目录，不动 enum 共享目录
- 顶层 models/index.ts 采用 读取-合并-去重-写回，保留其他服务导出
- isolateBySegment 始终基于原始服务总数，与过滤无关
- 失败时退出码置 1，错误信息列出可用服务
- 同步更新中英文文档与 package.json 测试脚本