### PR TITLE
修复异常命名转换问题

### DIFF
--- a/src/swagger-codegen/components/enum-parser.ts
+++ b/src/swagger-codegen/components/enum-parser.ts
@@ -10,6 +10,7 @@ import {
 	getEnumTypeName,
 	getServerSegment,
 	resolveSchemaName,
+	sanitizeIdentifierName,
 	typeNameToFileName,
 	wordsToPascalCase,
 } from '../shared/naming';
@@ -98,7 +99,7 @@ export class EnumParser {
 		const customName = customNames?.[index];
 
 		if (typeof customName === 'string' && customName.trim()) {
-			return customName;
+			return sanitizeIdentifierName(customName);
 		}
 
 		if (isNumericEnum || (typeof enumValue === 'string' && treatStringAsNumeric)) {
@@ -106,7 +107,7 @@ export class EnumParser {
 		}
 
 		if (typeof enumValue === 'string' && enumValue) {
-			return enumValue.toUpperCase();
+			return sanitizeIdentifierName(enumValue.toUpperCase());
 		}
 
 		return `ENUM_${index}`;
@@ -123,14 +124,14 @@ export class EnumParser {
 				// 使用排序后的键以确保顺序一致性
 				const enumValues = Object.entries(jsonObj)
 					.sort((a, b) => a[0].localeCompare(b[0]))
-					.map(([key, value]) => `${getIndentation(this.config)}${key}: '${String(value)}'`)
+					.map(([key, value]) => `${getIndentation(this.config)}${sanitizeIdentifierName(key)}: '${String(value)}'`)
 					.join(',\n');
 				return `export const ${enumName} = {\n${enumValues}\n} as const;\n\nexport type ${getEnumTypeName(this.config, enumName)} = typeof ${enumName}[keyof typeof ${enumName}];`;
 			} else {
 				// 使用排序后的键以确保顺序一致性
 				const enumValues = Object.entries(jsonObj)
 					.sort((a, b) => a[0].localeCompare(b[0]))
-					.map(([key, value]) => `${getIndentation(this.config)}${key} = '${String(value)}'`)
+					.map(([key, value]) => `${getIndentation(this.config)}${sanitizeIdentifierName(key)} = '${String(value)}'`)
 					.join(',\n');
 				return `export enum ${enumName} {\n${enumValues}\n}`;
 			}

--- a/src/swagger-codegen/components/schema-resolver.ts
+++ b/src/swagger-codegen/components/schema-resolver.ts
@@ -3,7 +3,16 @@ import type { OpenAPIV3 } from 'openapi-types';
 
 import { isValidJSON, log } from '../../utils';
 import { getIndentation } from '../shared/format';
-import { adjustImportPathForSegment, appendEnumSegment, getEnumSegment, getEnumTypeName, getServerSegment, resolveSchemaName, typeNameToFileName } from '../shared/naming';
+import {
+	adjustImportPathForSegment,
+	appendEnumSegment,
+	formatPropertyName,
+	getEnumSegment,
+	getEnumTypeName,
+	getServerSegment,
+	resolveSchemaName,
+	typeNameToFileName,
+} from '../shared/naming';
 import { nullableSuffix } from '../shared/schema-utils';
 import { EnumParser } from './enum-parser';
 
@@ -39,7 +48,10 @@ export class ComponentSchemaResolver {
 	}
 
 	private isRequired(fieldName: string): boolean {
-		return this.requiredFieldSet.has(fieldName);
+		// 属性名可能被 formatPropertyName 加上引号（如 "form-data"），
+		// 这里去掉引号以保证与 requiredFieldSet 中的原始名匹配
+		const unquoted = fieldName.startsWith('"') && fieldName.endsWith('"') ? fieldName.slice(1, -1) : fieldName;
+		return this.requiredFieldSet.has(unquoted);
 	}
 
 	private stringifyValue(value: unknown): string {
@@ -292,8 +304,11 @@ export class ComponentSchemaResolver {
 
 		// 使用 Object.keys() 并排序以确保顺序一致性
 		const propertyNames = Object.keys(properties).sort();
-		for (const name of propertyNames) {
-			const schemaSource = properties[name];
+		for (const rawName of propertyNames) {
+			const schemaSource = properties[rawName];
+			// 不规范属性名（如 form-data）使用引号包裹，
+			// 保留后端原始字段名，保证 JSON.stringify 后与 wire 协议一致
+			const name = formatPropertyName(rawName);
 
 			if ((schemaSource as ReferenceObject)?.$ref) {
 				const { headerRefStr, typeName, dataType } = this.parseRef((schemaSource as ReferenceObject).$ref);

--- a/src/swagger-codegen/path/index.ts
+++ b/src/swagger-codegen/path/index.ts
@@ -18,7 +18,7 @@ import type { OpenAPIV3 } from 'openapi-types';
 import { formatParseError, log } from '../../utils';
 import { applyFormattingDefaults, getIndentation } from '../shared/format';
 import { SUPPORTED_REQUEST_TYPES_ALL, SUPPORTED_REQUEST_UPLOAD_TYPES } from '../shared/http';
-import { formatPropertyName } from '../shared/naming';
+import { formatPropertyName, sanitizeIdentifierName } from '../shared/naming';
 import { convertEndpointString } from './naming';
 import { SchemaResolver } from './schema-resolver';
 import { PathWriter } from './writer';
@@ -211,13 +211,14 @@ export class PathParse {
 				const comments = this.generateParamComment(V2, doubleIndent);
 				comments.forEach((comment) => path.push(comment));
 
-				// Path 参数名可能包含中划线（如 {user-id}），需要用引号包裹
-				const propertyName = formatPropertyName(V2.name);
-				path.push(`${doubleIndent}${propertyName}: ${v2value};`);
+				// Path 参数名用作 JS 函数参数名，必须是合法标识符，中划线转下划线
+				// URL 模板中的 {user-id} 是纯字符串，不受影响
+				const paramName = sanitizeIdentifierName(V2.name);
+				path.push(`${doubleIndent}${paramName}: ${v2value};`);
 				if (this.contentBody.payload._path) {
-					this.contentBody.payload._path[V2.name] = v2value;
+					this.contentBody.payload._path[paramName] = v2value;
 				} else {
-					this.contentBody.payload._path = { [V2.name]: v2value };
+					this.contentBody.payload._path = { [paramName]: v2value };
 				}
 			} else if (V2.in === 'query') {
 				const comments = this.generateParamComment(V2, doubleIndent);

--- a/src/swagger-codegen/path/index.ts
+++ b/src/swagger-codegen/path/index.ts
@@ -211,7 +211,9 @@ export class PathParse {
 				const comments = this.generateParamComment(V2, doubleIndent);
 				comments.forEach((comment) => path.push(comment));
 
-				path.push(`${doubleIndent}type ${V2.name} = ${v2value};`);
+				// Path 参数名可能包含中划线（如 {user-id}），需要用引号包裹
+				const propertyName = formatPropertyName(V2.name);
+				path.push(`${doubleIndent}${propertyName}: ${v2value};`);
 				if (this.contentBody.payload._path) {
 					this.contentBody.payload._path[V2.name] = v2value;
 				} else {

--- a/src/swagger-codegen/shared/naming.ts
+++ b/src/swagger-codegen/shared/naming.ts
@@ -252,3 +252,14 @@ export function needsQuotes(propertyName: string): boolean {
 export function formatPropertyName(propertyName: string): string {
 	return needsQuotes(propertyName) ? `"${propertyName}"` : propertyName;
 }
+
+/**
+ * 清洗不规范的标识符名称：
+ * 将名称中的中划线 `-` 统一转成下划线 `_`，以便用于 TS 属性名 / 枚举成员名。
+ * 例如 `form-data` -> `form_data`，`LIST-CARD` -> `LIST_CARD`。
+ * 其他非法标识符字符不在此处处理，仍由 `needsQuotes` / `formatPropertyName` 决定是否加引号。
+ */
+export function sanitizeIdentifierName(name: string): string {
+	if (!name) return name;
+	return name.replace(/-/g, '_');
+}


### PR DESCRIPTION
✅ 新增 [sanitizeIdentifierName()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) 函数：中划线 - 转下划线 _
✅ 模型属性名用 [formatPropertyName()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) 加引号（保留原始字段名 ["form-data"](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)）
✅ 枚举成员名用 [sanitizeIdentifierName()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) 转下划线（[LIST_CARD](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)）但值保持 'LIST-CARD'
✅ [requiredFieldSet](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) 兼容去引号匹配必填字段